### PR TITLE
fix: the horizontal scroll bar appears when the task name is long

### DIFF
--- a/apps/web/src/app/[locale]/_components/FolderTreeItem.tsx
+++ b/apps/web/src/app/[locale]/_components/FolderTreeItem.tsx
@@ -185,11 +185,11 @@ export const FolderTreeItem = ({
           <div className="flex flex-1 justify-between" ref={setNodeRef}>
             <button
               type="button"
-              className="block w-full px-4 text-sm"
+              className="block flex-1 min-w-0 px-4 text-sm"
               onClick={toggleIsOpen}
             >
               <TreePath depth={depth}>
-                <span title={name} className="flex w-full min-w-0 items-center">
+                <span title={name} className="flex min-w-0 items-center">
                   <TreeItemArrowIcon isOpen={isOpen} />
                   <span style={{ color }} className="mr-2">
                     <PiFolder size={20} />

--- a/apps/web/src/app/[locale]/_components/TaskTreeItem.tsx
+++ b/apps/web/src/app/[locale]/_components/TaskTreeItem.tsx
@@ -128,7 +128,7 @@ export const TaskTreeItem = ({
       <div className="group flex hover:bg-gray-200">
         <button
           type="button"
-          className="block w-full px-4 text-sm"
+          className="block w-full min-w-0 px-4 text-sm"
           onClick={handleClick}
         >
           <TreePath depth={depth}>


### PR DESCRIPTION
Add `min-w-0` to hide the horizontal scrollbar.