### PR TITLE
feat(timer): add keyboard shortcut to toggle start/stop timer

### DIFF
--- a/apps/web/src/app/[locale]/_hooks/useKeyboardShortcut.test.ts
+++ b/apps/web/src/app/[locale]/_hooks/useKeyboardShortcut.test.ts
@@ -1,0 +1,169 @@
+import { cleanup } from "@testing-library/react";
+import { renderHook, act } from "src/test-utils";
+import { useKeyboardShortcut } from "./useKeyboardShortcut";
+
+// Mock navigator.platform
+const originalPlatform = navigator.platform;
+const mockPlatform = (platform: string) => {
+  Object.defineProperty(navigator, "platform", {
+    value: platform,
+    configurable: true,
+  });
+};
+
+beforeEach(() => {
+  cleanup();
+});
+
+afterEach(() => {
+  Object.defineProperty(navigator, "platform", {
+    value: originalPlatform,
+    configurable: true,
+  });
+});
+
+describe("useKeyboardShortcut", () => {
+  it("calls callback when Ctrl+S is pressed (non-Mac)", async () => {
+    mockPlatform("Win32");
+    const callback = vi.fn();
+
+    const { result } = renderHook(() =>
+      useKeyboardShortcut({ key: "s", callback }),
+    );
+
+    act(() => {
+      const event = new KeyboardEvent("keydown", {
+        key: "s",
+        ctrlKey: true,
+        bubbles: true,
+      });
+      window.dispatchEvent(event);
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls callback when Meta+S is pressed (Mac)", async () => {
+    mockPlatform("MacIntel");
+    const callback = vi.fn();
+
+    const { result } = renderHook(() =>
+      useKeyboardShortcut({ key: "s", callback }),
+    );
+
+    act(() => {
+      const event = new KeyboardEvent("keydown", {
+        key: "s",
+        metaKey: true,
+        bubbles: true,
+      });
+      window.dispatchEvent(event);
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT call callback when S is pressed without modifiers", async () => {
+    mockPlatform("Win32");
+    const callback = vi.fn();
+
+    const { result } = renderHook(() =>
+      useKeyboardShortcut({ key: "s", callback }),
+    );
+
+    act(() => {
+      const event = new KeyboardEvent("keydown", {
+        key: "s",
+        bubbles: true,
+      });
+      window.dispatchEvent(event);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call callback when Ctrl+Wrong is pressed", async () => {
+    mockPlatform("Win32");
+    const callback = vi.fn();
+
+    const { result } = renderHook(() =>
+      useKeyboardShortcut({ key: "s", callback }),
+    );
+
+    act(() => {
+      const event = new KeyboardEvent("keydown", {
+        key: "a",
+        ctrlKey: true,
+        bubbles: true,
+      });
+      window.dispatchEvent(event);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire inside an input element", async () => {
+    mockPlatform("Win32");
+    const callback = vi.fn();
+
+    renderHook(() =>
+      useKeyboardShortcut({ key: "s", callback, ignoreOnFormElements: true }),
+    );
+
+    act(() => {
+      const input = document.createElement("input");
+      document.body.appendChild(input);
+      input.focus();
+
+      const event = new KeyboardEvent("keydown", {
+        key: "s",
+        ctrlKey: true,
+        bubbles: true,
+      });
+      input.dispatchEvent(event);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("fires when disabled is false", async () => {
+    mockPlatform("Win32");
+    const callback = vi.fn();
+
+    const { result, rerender } = renderHook(({ enabled }) =>
+      useKeyboardShortcut({ key: "s", callback, enabled }),
+    );
+
+    rerender({ enabled: false });
+
+    act(() => {
+      const event = new KeyboardEvent("keydown", {
+        key: "s",
+        ctrlKey: true,
+        bubbles: true,
+      });
+      window.dispatchEvent(event);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("respects empty modifiers array (no modifier required)", async () => {
+    mockPlatform("Win32");
+    const callback = vi.fn();
+
+    renderHook(() =>
+      useKeyboardShortcut({ key: "s", callback, modifiers: [] }),
+    );
+
+    act(() => {
+      const event = new KeyboardEvent("keydown", {
+        key: "s",
+        bubbles: true,
+      });
+      window.dispatchEvent(event);
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/app/[locale]/_hooks/useKeyboardShortcut.ts
+++ b/apps/web/src/app/[locale]/_hooks/useKeyboardShortcut.ts
@@ -1,0 +1,94 @@
+import { useEffect, useCallback } from "react";
+
+type ModifierKey = "ctrlKey" | "shiftKey" | "altKey" | "metaKey";
+
+interface KeyboardShortcutOptions {
+  /**
+   * The key to listen for (e.g., "s", " ", "Enter").
+   * Case-insensitive.
+   */
+  key: string;
+  /**
+   * Which modifier keys must be held. Default: ["ctrlKey"] on non-mac, ["metaKey"] on mac.
+   * Pass an empty array to require no modifiers.
+   * Pass specific modifiers to override default behavior.
+   */
+  modifiers?: ModifierKey[];
+  /**
+   * Called when the shortcut is triggered.
+   */
+  callback: () => void;
+  /**
+   * Whether the shortcut is active. Default: true.
+   */
+  enabled?: boolean;
+  /**
+   * Tag name filter — prevents firing on inputs, textareas, etc. Default: true.
+   */
+  ignoreOnFormElements?: boolean;
+}
+
+/**
+ * Determines whether we're on a Mac for default modifier key selection.
+ */
+const isMac = () =>
+  typeof navigator !== "undefined" &&
+  /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+
+/**
+ * Returns the default modifier key based on platform.
+ */
+const defaultModifier = (): ModifierKey =>
+  isMac() ? "metaKey" : "ctrlKey";
+
+/**
+ * Registers a keyboard shortcut using keydown event listener.
+ * Fires callback when all conditions are met.
+ */
+export function useKeyboardShortcut({
+  key,
+  modifiers,
+  callback,
+  enabled = true,
+  ignoreOnFormElements = true,
+}: KeyboardShortcutOptions) {
+  const handler = useCallback(
+    (event: KeyboardEvent) => {
+      if (!enabled) return;
+
+      // Don't fire if user is typing in an input/textarea/contenteditable
+      if (ignoreOnFormElements) {
+        const target = event.target as HTMLElement;
+        const tagName = target?.tagName?.toLowerCase();
+        const isFormElement =
+          tagName === "input" ||
+          tagName === "textarea" ||
+          target?.isContentEditable;
+        if (isFormElement) return;
+      }
+
+      const requiredModifiers = modifiers ?? [defaultModifier()];
+
+      // Check all required modifiers are pressed
+      const modifiersMatch = requiredModifiers.every(
+        (mod) => event[mod] === true,
+      );
+
+      const keyMatches =
+        event.key.toLowerCase() === key.toLowerCase() ||
+        event.code.toLowerCase() === key.toLowerCase();
+
+      if (modifiersMatch && keyMatches) {
+        event.preventDefault();
+        callback();
+      }
+    },
+    [key, modifiers, callback, enabled, ignoreOnFormElements],
+  );
+
+  useEffect(() => {
+    if (!enabled) return;
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [handler, enabled]);
+}

--- a/apps/web/src/app/[locale]/app/(home)/_components/RunningTimeEntryForm.tsx
+++ b/apps/web/src/app/[locale]/app/(home)/_components/RunningTimeEntryForm.tsx
@@ -16,6 +16,7 @@ import { Duration } from "../../../_components/Duration";
 import { Tooltip } from "../../../_components/Tooltip";
 import { trpc } from "../../../_components/TrpcProvider";
 import { useToast } from "../../../_hooks/useToast";
+import { useKeyboardShortcut } from "../../../_hooks/useKeyboardShortcut";
 import { FolderSelect } from "./FolderSelect";
 import { RunningTimeEntryDescription } from "./RunningTimeEntryDescription";
 import { TaskSuggestionList } from "./TaskSuggestionList";
@@ -145,25 +146,7 @@ export const RunningTimeEntryForm = () => {
 
   const handleSubmit = async (event: SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault();
-
-    if (isRunning) {
-      await stopRunningTimeEntry.mutateAsync({
-        stoppedAt: new Date(),
-      });
-      if (selectedFolderId !== undefined) {
-        await utils.tasks.getTasksInFolder.invalidate({
-          folderId: selectedFolderId,
-        });
-      }
-    } else {
-      if (selectedFolderId !== undefined) {
-        await startRunningTimeEntry.mutateAsync({
-          folderId: selectedFolderId,
-          description: inputValue,
-          startedAt: new Date(),
-        });
-      }
-    }
+    await toggleTimer();
   };
 
   const handleDescriptionBlur = async () => {
@@ -196,6 +179,42 @@ export const RunningTimeEntryForm = () => {
       await updateRunningTimeEntry.mutateAsync({ folderId });
     }
   };
+
+  const toggleTimer = useCallback(async () => {
+    if (runningTimeEntry.isLoading) return;
+    if (isRunning) {
+      await stopRunningTimeEntry.mutateAsync({
+        stoppedAt: new Date(),
+      });
+      if (selectedFolderId !== undefined) {
+        await utils.tasks.getTasksInFolder.invalidate({
+          folderId: selectedFolderId,
+        });
+      }
+    } else {
+      if (selectedFolderId !== undefined) {
+        await startRunningTimeEntry.mutateAsync({
+          folderId: selectedFolderId,
+          description: inputValue,
+          startedAt: new Date(),
+        });
+      }
+    }
+  }, [
+    isRunning,
+    selectedFolderId,
+    inputValue,
+    runningTimeEntry.isLoading,
+    stopRunningTimeEntry,
+    startRunningTimeEntry,
+    utils,
+  ]);
+
+  useKeyboardShortcut({
+    key: "s",
+    callback: toggleTimer,
+    enabled: !runningTimeEntry.isLoading,
+  });
 
   return (
     <form onSubmit={(event) => void handleSubmit(event)}>


### PR DESCRIPTION
## Summary

Adds a keyboard shortcut (Ctrl+S / Cmd+S) to toggle the timer start/stop without clicking. Fixes #339.

## Changes

- **New hook**: `useKeyboardShortcut` in `apps/web/src/app/[locale]/_hooks/`
  - Detects key + modifier combinations
  - Auto-selects `ctrlKey` on Windows/Linux, `metaKey` on Mac
  - Ignores shortcuts when user is typing in `input`/`textarea`/contenteditable
  - Supports disabling, custom modifier lists, and form element ignore toggle

- **Refactored `RunningTimeEntryForm`**:
  - Extracted shared `toggleTimer` callback used by both the button and shortcut
  - `handleSubmit` now delegates to `toggleTimer` — single source of truth

- **Tests**: `useKeyboardShortcut.test.ts` covers:
  - Ctrl+S on non-Mac, Meta+S on Mac
  - No false fires without modifier
  - No fires inside form elements
  - Disabled state
  - Empty modifiers array