### PR TITLE
feat: display timer in page title while running

### DIFF
--- a/apps/web/e2e/home.spec.ts
+++ b/apps/web/e2e/home.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
 import { sessionFactory } from "@minute/prisma/vitest/factories";
 import { test, expect } from "@playwright/test";
 import { addDays } from "date-fns";
@@ -53,6 +54,55 @@ test.describe("when a user is signed in", () => {
     await expect(
       page.getByRole("button", { name: /example task/ }),
     ).toBeVisible();
+    await browser.close();
+  });
+
+  test("displays timer in page title when running", async ({ browser }) => {
+    const session = await sessionFactory
+      .props({ expires: () => addDays(new Date(), 1) })
+      .create();
+    const context = await browser.newContext();
+    await context.addCookies([
+      {
+        name: "next-auth.session-token",
+        domain: "localhost",
+        path: "/",
+        value: session.sessionToken,
+        httpOnly: true,
+        sameSite: "Lax",
+      },
+    ]);
+    const page = await context.newPage();
+
+    await page.goto("/app");
+    await expect(page).toHaveURL("/en/app");
+
+    // Initially, title should be just "minute"
+    await expect(page).toHaveTitle("minute");
+
+    // Create a folder and start timer
+    await page.getByRole("button", { name: "Add New Folder" }).click();
+    await page.getByPlaceholder("Enter folder name...").fill("test");
+    await page.getByRole("main").click();
+    await page
+      .getByPlaceholder("Enter the description of what")
+      .fill("example task");
+    await page.getByRole("main").click();
+    await page.getByLabel("Start Working").click();
+    await expect(page.getByLabel("Stop Working")).toBeVisible();
+
+    // Title should show timer with description
+    await expect(async () => {
+      const title = await page.title();
+      expect(title).toMatch(/^\d{2}:\d{2}:\d{2}・example task - minute$/);
+    }).toPass({ timeout: 2000 });
+
+    // Stop timer
+    await page.getByLabel("Stop Working").click();
+
+    // Title should return to "minute"
+    await expect(page).toHaveTitle("minute");
+
     await browser.close();
   });
 });

--- a/apps/web/src/app/[locale]/_components/PageTitle.tsx
+++ b/apps/web/src/app/[locale]/_components/PageTitle.tsx
@@ -23,6 +23,9 @@ export const PageTitle = () => {
     } else {
       document.title = "minute";
     }
+    return () => {
+      document.title = "minute";
+    };
   }, [runningTimeEntry.data, duration]);
 
   return null;

--- a/apps/web/src/app/[locale]/_components/PageTitle.tsx
+++ b/apps/web/src/app/[locale]/_components/PageTitle.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { fromS } from "hh-mm-ss";
+import { useEffect } from "react";
+import { useDuration } from "../_hooks/useDuration";
+import { trpc } from "./TrpcProvider";
+
+export const PageTitle = () => {
+  const runningTimeEntry = trpc.runningTimeEntry.getRunningTimeEntry.useQuery(
+    undefined,
+    {
+      refetchOnWindowFocus: true,
+    },
+  );
+
+  const duration = useDuration(runningTimeEntry.data?.startedAt);
+
+  useEffect(() => {
+    if (runningTimeEntry.data) {
+      const formattedDuration = fromS(duration, "hh:mm:ss");
+      const description = runningTimeEntry.data.description || "";
+      document.title = `${formattedDuration}・${description} - minute`;
+    } else {
+      document.title = "minute";
+    }
+  }, [runningTimeEntry.data, duration]);
+
+  return null;
+};

--- a/apps/web/src/app/[locale]/app/layout.tsx
+++ b/apps/web/src/app/[locale]/app/layout.tsx
@@ -1,9 +1,11 @@
+import { PageTitle } from "../_components/PageTitle";
 import { Sidebar } from "../_components/Sidebar";
 
 const Layout = ({ children }: LayoutProps<"/[locale]/app">) => {
   return (
     <div className="flex">
       <h1 className="sr-only">minute</h1>
+      <PageTitle />
       <Sidebar />
       <main className="flex-1">{children}</main>
     </div>


### PR DESCRIPTION
## Summary
- Display the active timer duration in the browser tab title (e.g., "01:23:45 - minute") so users can see elapsed time without switching tabs
- Restore the original page title when the timer stops or the component unmounts

Fixes #114

## Test plan
- [ ] Added Playwright e2e tests verifying the page title updates with the timer format and resets on stop
- [ ] Start a timer, switch to another tab, and verify the timer is visible in the tab title
- [ ] Stop the timer and verify the page title reverts to the default